### PR TITLE
Interventions UI github status webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ To populate,
 
 ```
 cd seed
-CIRCLE_TOKEN=token PACT_BROKER_USERNAME=username PACT_BROKER_PASSWORD=password ./create_webhooks.sh
+CIRCLE_TOKEN=token GITHUB_ACCESS_TOKEN=token PACT_BROKER_USERNAME=username PACT_BROKER_PASSWORD=password ./create_webhooks.sh
 ```
 
 - `CIRCLE_TOKEN` to be used by webhooks to CircleCI, used by the CircleCI v2 API. Please generate one.
+- `GITHUB_ACCESS_TOKEN` to be used by Pact to signal the verification result as a GitHub status. Needs a [personal access token][pat], and [authorised SAML][saml].
 - `PACT_BROKER_USERNAME` and `PACT_BROKER_PASSWORD` are the basic auth username/password. Please see the Kubernetes secrets.
 
 :rotating_light: The tokens are redacted in the output and the Pact broker UI.
@@ -40,3 +41,6 @@ However, they are visible in the database.
 ## Secrets
 
 All variables are saved in the Kubernetes secrets under the namespace `pact-broker-prod`.
+
+[pat]: https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token
+[saml]: https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on

--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -6,9 +6,19 @@ if [ "$CIRCLE_TOKEN" = "" ] || [ "$GITHUB_ACCESS_TOKEN" = "" ] || [ "$PACT_BROKE
   exit 1
 fi
 
+# these ".../webhooks/ID" IDs are randomly chosen -- they will be either "created or updated" so pick any new webhooks
+# for pedantics: Pact generates these via `SecureRandom.urlsafe_base64`: https://ruby-doc.org/stdlib-3.0.1/libdoc/securerandom/rdoc/Random/Formatter.html#method-i-urlsafe_base64
+
 sed "s/\${CIRCLE_TOKEN}/$CIRCLE_TOKEN/; s/\${GITHUB_ACCESS_TOKEN}/$GITHUB_ACCESS_TOKEN/" webhook-interventions-service.json |
   curl -X PUT \
     "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/webhooks/4wniGo-GXnLTM6Qx1YqlmQ" \
+    --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD" \
+    -H "Content-Type: application/json" \
+    -d @-
+
+sed "s/\${CIRCLE_TOKEN}/$CIRCLE_TOKEN/; s/\${GITHUB_ACCESS_TOKEN}/$GITHUB_ACCESS_TOKEN/" webhook-interventions-ui-feedback.json |
+  curl -X PUT \
+    "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/webhooks/3XLeJJv8Lh4yiTk0nBDMoQ" \
     --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD" \
     -H "Content-Type: application/json" \
     -d @-

--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -e
 
-if [ "$CIRCLE_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
+if [ "$CIRCLE_TOKEN" = "" ] || [ "$GITHUB_ACCESS_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
   echo "One or more environment variables are missing. Usage:"
-  echo "CIRCLE_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
+  echo "CIRCLE_TOKEN=token GITHUB_ACCESS_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
   exit 1
 fi
 
-sed "s/\${CIRCLE_TOKEN}/$CIRCLE_TOKEN/" webhook-interventions-service.json |
+sed "s/\${CIRCLE_TOKEN}/$CIRCLE_TOKEN/; s/\${GITHUB_ACCESS_TOKEN}/$GITHUB_ACCESS_TOKEN/" webhook-interventions-service.json |
   curl -X PUT \
     "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/webhooks/4wniGo-GXnLTM6Qx1YqlmQ" \
     --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD" \

--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-if [ "x$CIRCLE_TOKEN" = "x" ] || [ "x$PACT_BROKER_USERNAME" = "x" ] || [ "x$PACT_BROKER_PASSWORD" = "x" ]; then
+if [ "$CIRCLE_TOKEN" = "" ] || [ "$PACT_BROKER_USERNAME" = "" ] || [ "$PACT_BROKER_PASSWORD" = "" ]; then
   echo "One or more environment variables are missing. Usage:"
   echo "CIRCLE_TOKEN=token PACT_BROKER_USERNAME=user PACT_BROKER_PASSWORD=password $0"
   exit 1

--- a/seed/webhook-interventions-ui-feedback.json
+++ b/seed/webhook-interventions-ui-feedback.json
@@ -1,0 +1,27 @@
+{
+  "consumer": {
+    "name": "Interventions UI"
+  },
+  "events": [
+    {
+      "name": "contract_published"
+    },
+    {
+      "name": "provider_verification_published"
+    }
+  ],
+  "request": {
+    "method": "POST",
+    "url": "https://api.github.com/repos/ministryofjustice/hmpps-interventions-ui/statuses/${pactbroker.consumerVersionNumber}",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "token ${GITHUB_ACCESS_TOKEN}"
+    },
+    "body": {
+      "state": "${pactbroker.githubVerificationStatus}",
+      "description": "Pact Verification Tests ${pactbroker.providerVersionTags}",
+      "context": "pact/provider/${pactbroker.providerName}",
+      "target_url": "${pactbroker.verificationResultUrl}"
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Adds a new webhook to Pact broker

- when the contract is published: post a ⏳ pending status on the intervention-ui commit
- when a verification is completed: post a 👍 or 👎 status on the intervention-ui commit

This introduces `GITHUB_ACCESS_TOKEN` as an input to the webhooks.

## What is the intent behind these changes?

Make sure UI is aware if it broke pacts or not

http://blog.pact.io/2020/02/24/how-we-have-fixed-the-biggest-problem-with-the-pact-workflow/ is a relevant post