### PR TITLE
✨ PIC-1507: Add prepare-a-case webhooks

### DIFF
--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -21,3 +21,5 @@ function upsert_webhook() {
 # for pedantics: Pact generates these via `SecureRandom.urlsafe_base64`: https://ruby-doc.org/stdlib-3.0.1/libdoc/securerandom/rdoc/Random/Formatter.html#method-i-urlsafe_base64
 upsert_webhook "webhook-interventions-service.json" "4wniGo-GXnLTM6Qx1YqlmQ"
 upsert_webhook "webhook-interventions-ui-feedback.json" "3XLeJJv8Lh4yiTk0nBDMoQ"
+upsert_webhook "webhook-court-case-service.json" "357828ada55a4ba1bf4f3bd846ed4d96"
+upsert_webhook "webhook-prepare-a-case-feedback.json" "90a734c0f0654594a76c7472e0f3646a"

--- a/seed/webhook-court-case-service.json
+++ b/seed/webhook-court-case-service.json
@@ -1,0 +1,26 @@
+{
+  "description": "Trigger court-case-service pact",
+  "provider": {
+    "name": "court-case-service"
+  },
+  "events": [
+    {
+      "name": "contract_content_changed"
+    }
+  ],
+  "request": {
+    "method": "POST",
+    "url": "https://circleci.com/api/v2/project/github/ministryofjustice/court-case-service/pipeline",
+    "headers": {
+      "Content-Type": "application/json",
+      "Circle-Token": "${CIRCLE_TOKEN}"
+    },
+    "body": {
+      "branch": "main",
+      "parameters": {
+        "only_pacts": true,
+        "pact_consumer_tags": "${pactbroker.consumerVersionTags}"
+      }
+    }
+  }
+}

--- a/seed/webhook-prepare-a-case-feedback.json
+++ b/seed/webhook-prepare-a-case-feedback.json
@@ -1,0 +1,27 @@
+{
+  "consumer": {
+    "name": "prepare-a-case"
+  },
+  "events": [
+    {
+      "name": "contract_published"
+    },
+    {
+      "name": "provider_verification_published"
+    }
+  ],
+  "request": {
+    "method": "POST",
+    "url": "https://api.github.com/repos/ministryofjustice/prepare-a-case/statuses/${pactbroker.consumerVersionNumber}",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "token ${GITHUB_ACCESS_TOKEN}"
+    },
+    "body": {
+      "state": "${pactbroker.githubVerificationStatus}",
+      "description": "Pact Verification Tests ${pactbroker.providerVersionTags}",
+      "context": "pact/provider/${pactbroker.providerName}",
+      "target_url": "${pactbroker.verificationResultUrl}"
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Adds webhooks to trigger court-case-service builds when new contracts are published and reports verification status to prepare-a-case.

## What is the intent behind these changes?

Shorten Pact feedback cycles in prepare-a-case and court-case-service
