### PR TITLE
Pin broker image to last known working version

### DIFF
--- a/kubectl-deploy/deployment.yml
+++ b/kubectl-deploy/deployment.yml
@@ -13,7 +13,7 @@ spec:
         app: pact-broker
     spec:
       containers:
-      - image: pactfoundation/pact-broker:2
+      - image: pactfoundation/pact-broker:2.81.0.1
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: True


### PR DESCRIPTION


## What does this pull request do?

Makes broker deployment working again

## What is the intent behind these changes?
Newer versions (2.81.0.2 and 2.83.0.0 so far) give this error:

```
bundler: command not found: puma
Install missing gem executables with `bundle install`
```
