### PR TITLE
Bump uid of ruby user in deployment

### DIFF
--- a/kubectl-deploy/deployment.yml
+++ b/kubectl-deploy/deployment.yml
@@ -17,7 +17,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: True
-          runAsUser: 100
+          runAsUser: 101
         name: app
         readinessProbe:
           tcpSocket:


### PR DESCRIPTION

## What does this pull request do?

Match the UID of the `ruby` user in the image at runtime

This fixes
```
`/pact_broker` is not writable.
Bundler will use `/tmp/bundler20210831-7-10qggcu7' as your home directory temporarily.
```
errors at the beginning

(But this does not solve the problem worked around in c20ca4fcf2859dc1a20910afd388558d59145eab)

## What is the intent behind these changes?

Since the introduction of this UID, the image has bumped into uid 101:
```
$ docker run --rm -ti --entrypoint='/usr/bin/id' pactfoundation/pact-broker:2.76.0.0
uid=100(ruby) gid=0(root) groups=0(root)

$ docker run --rm -ti --entrypoint='/usr/bin/id' pactfoundation/pact-broker:2.78.0.0
uid=101(ruby) gid=0(root) groups=0(root)

$ docker run --rm -ti --entrypoint='/usr/bin/id' pactfoundation/pact-broker:2.81.0.1
uid=101(ruby) gid=0(root) groups=0(root)
```

We need a numeric ID due to how we verify non-root users:
```
message: container has runAsNonRoot and image has non-numeric user (ruby),
  cannot verify user is non-root
```