### PR TITLE
PUD-792: Add webhooks for the manage-recalls apps.

### DIFF
--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -22,7 +22,9 @@ function upsert_webhook() {
 
 # these ".../webhooks/ID" IDs are randomly chosen -- they will be either "created or updated" so pick anything for new webhooks
 # for pedantics: Pact generates these via `SecureRandom.urlsafe_base64`: https://ruby-doc.org/stdlib-3.0.1/libdoc/securerandom/rdoc/Random/Formatter.html#method-i-urlsafe_base64
+upsert_webhook "webhook-court-case-service.json" "357828ada55a4ba1bf4f3bd846ed4d96"
 upsert_webhook "webhook-interventions-service.json" "4wniGo-GXnLTM6Qx1YqlmQ"
 upsert_webhook "webhook-interventions-ui-feedback.json" "3XLeJJv8Lh4yiTk0nBDMoQ"
-upsert_webhook "webhook-court-case-service.json" "357828ada55a4ba1bf4f3bd846ed4d96"
+upsert_webhook "webhook-manage-recalls-api.json" "6FuVcYEPZt51S0rd1G8jRw"
+upsert_webhook "webhook-manage-recalls-ui-feedback.json" "AQv2iulu8UgXL552jeBC6Q"
 upsert_webhook "webhook-prepare-a-case-feedback.json" "90a734c0f0654594a76c7472e0f3646a"

--- a/seed/webhook-manage-recalls-api.json
+++ b/seed/webhook-manage-recalls-api.json
@@ -1,0 +1,26 @@
+{
+  "description": "Trigger manage-recalls-api pact",
+  "provider": {
+    "name": "manage-recalls-api"
+  },
+  "events": [
+    {
+      "name": "contract_content_changed"
+    }
+  ],
+  "request": {
+    "method": "POST",
+    "url": "https://circleci.com/api/v2/project/github/ministryofjustice/manage-recalls-api/pipeline",
+    "headers": {
+      "Content-Type": "application/json",
+      "Circle-Token": "${CIRCLE_TOKEN}"
+    },
+    "body": {
+      "branch": "main",
+      "parameters": {
+        "only_run_pact_workflow": true,
+        "pact_consumer_tags": "${pactbroker.consumerVersionTags}"
+      }
+    }
+  }
+}

--- a/seed/webhook-manage-recalls-ui-feedback.json
+++ b/seed/webhook-manage-recalls-ui-feedback.json
@@ -1,0 +1,27 @@
+{
+  "consumer": {
+    "name": "manage-recalls-ui"
+  },
+  "events": [
+    {
+      "name": "contract_published"
+    },
+    {
+      "name": "provider_verification_published"
+    }
+  ],
+  "request": {
+    "method": "POST",
+    "url": "https://api.github.com/repos/ministryofjustice/manage-recalls-ui/statuses/${pactbroker.consumerVersionNumber}",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "token ${GITHUB_ACCESS_TOKEN}"
+    },
+    "body": {
+      "state": "${pactbroker.githubVerificationStatus}",
+      "description": "Pact Verification Tests ${pactbroker.providerVersionTags}",
+      "context": "pact/provider/${pactbroker.providerName}",
+      "target_url": "${pactbroker.verificationResultUrl}"
+    }
+  }
+}


### PR DESCRIPTION
Question - will the `$CIRCLE_TOKEN` and `$GITHUB_ACCESS_TOKEN` currently in the repo secrets have access to these CircleCI builds and github repos? If not, how can I give them access?

## What does this pull request do?

This adds the webhooks for the manage-recalls services to re-verify the pacts upon changes.

## What is the intent behind these changes?

To try and make our "webhook status" column useful...
