### PR TITLE
Delete the manage-recalls webhooks.

### DIFF
--- a/seed/create-webhooks.sh
+++ b/seed/create-webhooks.sh
@@ -20,11 +20,25 @@ function upsert_webhook() {
   echo
 }
 
+function delete_webhook() {
+  local webhookID="$1"
+  echo "💥 deleting webhook $1..."
+  curl -X DELETE \
+    "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/webhooks/$webhookID" \
+    --user "$PACT_BROKER_USERNAME:$PACT_BROKER_PASSWORD"
+  echo
+  echo
+}
+
+# Temporarily remove the "manage-recalls" webhooks to clear old state etc
+delete_webhook "6FuVcYEPZt51S0rd1G8jRw"
+delete_webhook "AQv2iulu8UgXL552jeBC6Q"
+
 # these ".../webhooks/ID" IDs are randomly chosen -- they will be either "created or updated" so pick anything for new webhooks
 # for pedantics: Pact generates these via `SecureRandom.urlsafe_base64`: https://ruby-doc.org/stdlib-3.0.1/libdoc/securerandom/rdoc/Random/Formatter.html#method-i-urlsafe_base64
 upsert_webhook "webhook-court-case-service.json" "357828ada55a4ba1bf4f3bd846ed4d96"
 upsert_webhook "webhook-interventions-service.json" "4wniGo-GXnLTM6Qx1YqlmQ"
 upsert_webhook "webhook-interventions-ui-feedback.json" "3XLeJJv8Lh4yiTk0nBDMoQ"
-upsert_webhook "webhook-manage-recalls-api.json" "6FuVcYEPZt51S0rd1G8jRw"
-upsert_webhook "webhook-manage-recalls-ui-feedback.json" "AQv2iulu8UgXL552jeBC6Q"
+# upsert_webhook "webhook-manage-recalls-api.json" "6FuVcYEPZt51S0rd1G8jRw"
+# upsert_webhook "webhook-manage-recalls-ui-feedback.json" "AQv2iulu8UgXL552jeBC6Q"
 upsert_webhook "webhook-prepare-a-case-feedback.json" "90a734c0f0654594a76c7472e0f3646a"


### PR DESCRIPTION
They seem to be in a state where the pact broker is holding onto the
results of some old hooks, this should clear it out... fingers crossed.