### PR TITLE
Use contract_requiring_verification_published event for manage recalls to try to fix the stalemate when PACT fails because the API hasnt implemented the contract correctly

### DIFF
--- a/seed/webhook-manage-recalls-api.json
+++ b/seed/webhook-manage-recalls-api.json
@@ -5,7 +5,7 @@
   },
   "events": [
     {
-      "name": "contract_content_changed"
+      "name": "contract_requiring_verification_published"
     }
   ],
   "request": {

--- a/seed/webhook-manage-recalls-ui-feedback.json
+++ b/seed/webhook-manage-recalls-ui-feedback.json
@@ -4,7 +4,7 @@
   },
   "events": [
     {
-      "name": "contract_published"
+      "name": "contract_requiring_verification_published"
     },
     {
       "name": "provider_verification_published"


### PR DESCRIPTION

## What does this pull request do?

Uses different event for manage recalls webhooks

## What is the intent behind these changes?

To try to get PACT to re-validate the UI when the API is changed after PACT fails
